### PR TITLE
Add Third Party Libs and Blog Posts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ A *work-in-progress* implementation of GraphQL for Go.
 
 This project was originally a port of [v0.4.3](https://github.com/graphql/graphql-js/releases/tag/v0.4.3) of [graphql-js](https://github.com/graphql/graphql-js) (excluding the Validator), which was based on the July 2015 GraphQL specification. `graphql` is currently several versions behind `graphql-js`, however future efforts will be guided directly by the [latest formal GraphQL specification](https://github.com/facebook/graphql/releases) (currently: [October 2015](https://github.com/facebook/graphql/releases/tag/October2015)).
 
+### Install
+`go get https://github.com/chris-ramon/graphql-go`
+
+### Third Party Libraries
+| Name          | Author        | Description  |
+|:-------------:|:-------------:|:------------:|
+| [graphql-go-handler](https://github.com/sogko/graphql-go-handler) | [Hafiz Ismail](https://github.com/sogko) | Middleware to handle GraphQL queries through HTTP requests. |
+
+### Blog Posts
+* [Golang + GraphQL + Relay](http://wehavefaces.net/)
+
 ### Roadmap
 - [x] Lexer
 - [x] Parser


### PR DESCRIPTION
- Adds third party libraries & blog posts sections to `README`.
- Splitted from [this](https://github.com/chris-ramon/graphql/pull/34) initial PR.